### PR TITLE
Make vendor/tng to use local lib/colors

### DIFF
--- a/vendor/tng.js
+++ b/vendor/tng.js
@@ -29,7 +29,7 @@ function PNG(file, options) {
   if (!file) throw new Error('no file');
 
   this.options = options || {};
-  this.colors = options.colors || require('blessed/lib/colors');
+  this.colors = options.colors || require('../lib/colors');
   this.optimization = this.options.optimization || 'mem';
   this.speed = this.options.speed || 1;
 


### PR DESCRIPTION
Importing `lib/colors` with a relative path remove errors when building an app using webpack.